### PR TITLE
Dashboard generator should skip Plain Ruby Objects, not backed by ActiveRecord, without raising an exception and halting mid process.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ rescue LoadError
 end
 
 require 'rdoc/task'
-
+require 'rspec/core/rake_task'
 require File.expand_path('../spec/example_app/config/application', __FILE__)
 
 RDoc::Task.new(:rdoc) do |rdoc|

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -117,6 +117,8 @@ module Administrate
         else
           ""
         end
+      rescue
+        ""
       end
 
       def options_string(options)

--- a/lib/generators/administrate/dashboard/dashboard_generator.rb
+++ b/lib/generators/administrate/dashboard/dashboard_generator.rb
@@ -45,6 +45,8 @@ module Administrate
 
       def attributes
         klass.reflections.keys + klass.attribute_names - redundant_attributes
+      rescue
+        []
       end
 
       def form_attributes

--- a/spec/generators/dashboard_generator_spec.rb
+++ b/spec/generators/dashboard_generator_spec.rb
@@ -12,6 +12,18 @@ describe Administrate::Generators::DashboardGenerator, :generator do
       expect(dashboard).to have_correct_syntax
     end
 
+    describe 'plain ruby objects' do
+      it 'skips over plain ruby objects because they do not have reflection' do
+        class PlainRubyObject
+          attr_accessor :name, :stage
+        end
+
+        expect do
+          run_generator ["plain_ruby_object"]
+        end.to_not raise_error
+      end
+    end
+
     describe "#attribute_types" do
       it "includes standard model attributes" do
         begin


### PR DESCRIPTION
Running `rails generate administrate:install` on a project would fail part way through if the project contained non-ActiveRecord Ruby objects in the models folder. I've added a test to exercise this bug and two rescues in the dashboard_generator to return an empty value when the case is encountered. The goal is that the non-database object should be skipped. All tests are passing.
